### PR TITLE
close #11 实现check_user接口

### DIFF
--- a/api/info.go
+++ b/api/info.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"Miniprogram-server-Golang/service"
+	"github.com/gin-gonic/gin"
+)
+
+// GetBindInfo 检查用户绑定信息接口
+func GetBindInfo(c *gin.Context) {
+	var service service.GetBindInfoService
+	if err := c.ShouldBind(&service); err == nil {
+		res := service.GetBindInfo(c)
+		c.JSON(200, res)
+	} else {
+		c.JSON(200, ErrorResponse(err))
+	}
+}

--- a/api/user.go
+++ b/api/user.go
@@ -73,6 +73,7 @@ func GetCorp(c *gin.Context) {
 
 // CheckUser 检查用户是否存在
 func CheckUser(c *gin.Context) {
+	//	将请求的内容通过ShouldBind方法绑定到service中。每一个接口中对应的service
 	var service service.CheckUserService
 	if err := c.ShouldBind(&service); err == nil {
 		res := service.CheckUser(c)

--- a/model/migration.go
+++ b/model/migration.go
@@ -8,4 +8,7 @@ func migration() {
 	DB.AutoMigrate(&DailyInfo{})
 	DB.AutoMigrate(&Corp{})
 	DB.AutoMigrate(&Student{})
+
+	//临时
+	DB.AutoMigrate(&WxMpBindInfo{})
 }

--- a/model/mpbind.go
+++ b/model/mpbind.go
@@ -1,0 +1,13 @@
+package model
+
+import "github.com/jinzhu/gorm"
+
+//	临时创建使用，后面按照命名规则和规定属性等再进行修改
+//	对应数据库中的wx_mp_bind_info表
+type WxMpBindInfo struct {
+	gorm.Model
+	OrgId		uint
+	WxUid		string
+	Username	string
+	Isbind		int
+}

--- a/model/user.go
+++ b/model/user.go
@@ -33,6 +33,8 @@ type Corp struct {
 	TypeUsername string
 }
 
+
+
 const (
 	// PassWordCost 密码加密难度
 	PassWordCost = 12

--- a/serializer/info.go
+++ b/serializer/info.go
@@ -1,0 +1,23 @@
+package serializer
+
+// isRegistered 用户序列化器
+type BindInfo struct {
+	ErrCode	int	`json:"errcode"`
+	IsBind	int	`json:"is_bind"`
+	CorpCode	string	`json:"corp_code"`
+}
+
+// BuildBindInfo 序列化
+func BuildBindInfo(errCode int, isBind int, corpCode string) BindInfo {
+	return BindInfo{
+		ErrCode:errCode,
+		IsBind:isBind,
+		CorpCode:corpCode,
+	}
+}
+
+func BuildBindInfoResponse(errCode int, isBind int, corpCode string) Response {
+	return Response{
+		Data: BuildBindInfo(errCode, isBind, corpCode),
+	}
+}

--- a/server/router.go
+++ b/server/router.go
@@ -33,6 +33,7 @@ func NewRouter() *gin.Engine {
 
 		//用户解绑
 		v1.POST("/unbind", api.UserUnBind)
+
 	}
 
 	// 路由，用户上传信息接口
@@ -50,6 +51,9 @@ func NewRouter() *gin.Engine {
 	{
 		//获取用户信息
 		v3.POST("/getmyinfo", api.GetUserInfo)
+
+		//检查用户绑定信息
+		v3.POST("/getbindinfo", api.GetBindInfo)
 	}
 
 	return router

--- a/service/check_user.go
+++ b/service/check_user.go
@@ -14,17 +14,34 @@ type CheckUserService struct {
 	Token  string `form:"token" json:"token"`
 }
 
-// isRegistered 判断用户是否注册过
+// 用于检测用户标识是否已经被绑定
 func (service *CheckUserService) CheckUser(c *gin.Context) serializer.Response {
 	if !model.CheckToken(service.Uid, service.Token) {
 		return serializer.ParamErr("token验证错误", nil)
 	}
 
-	//再搜索数据库，判断是否存在该用户
-	count := 0
-	if model.DB.Model(&model.Student{}).Where(&model.Student{Uid: service.Uid}).Count(&count); count == 0 {
-		return serializer.BuildUserCheckResponse(0, service.Corpid, service.UserId)
+	//	根据corpid找到公司名称
+	var corp model.Corp
+	if err := model.DB.Where(&model.Corp{Corpid: service.Corpid}).First(&corp); err != nil {
+		return serializer.Err(10006, "获取企业信息失败", nil)
 	}
 
-	return serializer.BuildUserCheckResponse(1, service.Corpid, service.UserId)
+	corpid := corp.ID
+	//	根据corpid查找用户-企业绑定信息
+	var corpBind model.WxMpBindInfo
+	if err := model.DB.Where(&model.WxMpBindInfo{OrgId:corpid, Username:service.UserId, Isbind:1}).First(&corpBind); err != nil {
+		//	错误码未知，张老师没有写到，有待修改
+		return serializer.Err(100019, "用户和企业未绑定", nil)
+	}
+
+	wxuid := corpBind.WxUid
+
+	if wxuid == service.Uid {
+		//	正确的返回结果
+		return serializer.BuildUserCheckResponse(0, service.Corpid, service.UserId)
+	} else {
+		//	这里不确定是返回错误信息还是显示用户已存在。接口文档和php代码不一致，目前以php代码为准
+		return serializer.Err(100020, "该用户已被其他微信绑定，每个用户只能被一个微信绑定", nil)
+		//return serializer.BuildUserCheckResponse(1, service.Corpid, service.UserId)
+	}
 }

--- a/service/get_bind_info.go
+++ b/service/get_bind_info.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"Miniprogram-server-Golang/model"
+	"Miniprogram-server-Golang/serializer"
+	"github.com/gin-gonic/gin"
+)
+
+type GetBindInfoService struct {
+	Uid    string `form:"uid" json:"uid"`
+	Token  string `form:"token" json:"token"`
+}
+
+type BindInfo struct {
+	Orgid		uint
+	Corpid		string
+	Corpname	string
+}
+
+func (service *GetBindInfoService) GetBindInfo(c *gin.Context) serializer.Response{
+	if !model.CheckToken(service.Uid, service.Token) {
+		return serializer.ParamErr("token验证错误", nil)
+	}
+
+	var bindInfo BindInfo
+	if err := model.DB.Model(model.WxMpBindInfo{}).Select("wx_mp_bind_infos.orgid, corps.corpid, corps.corpname").Joins("left join corps on corps.id = wx_mp_bind_infos.orgid").Where(model.WxMpBindInfo{Isbind:1, WxUid: service.Uid}).First(&bindInfo); err != nil {
+		return serializer.BuildBindInfoResponse(0, 0, "")
+	} else {
+		bindCorpid := bindInfo.Corpid
+		return serializer.BuildBindInfoResponse(0, 1, bindCorpid)
+	}
+
+}


### PR DESCRIPTION
close #11 

- 添加临时用model WxMpBindInfo及migration.go中的相应配置，留待规范化修改
- 实现check_user.go中的CheckUser接口功能，一些疑问写在注释中，后续解决后即删除

close #14 

- 新增 /getbindinfo 路由项
- 新增 GetBindInfo接口， 写入新文件api/info.go
- 新增 GetBindInfoService服务
- 新增 BindInfo的相关序列化结构和方法，写入新文件serializer/info.go
